### PR TITLE
Relax FSharp.Core and Serilog dependencies

### DIFF
--- a/src/Destructurama.FSharp/Destructurama.FSharp.fsproj
+++ b/src/Destructurama.FSharp/Destructurama.FSharp.fsproj
@@ -6,6 +6,8 @@
      -->
     <TargetFrameworks>netstandard1.6;netstandard2.0</TargetFrameworks>
     <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
+    <DisableImplicitSystemValueTupleReference>true</DisableImplicitSystemValueTupleReference>
+    <WarningLevel>5</WarningLevel>
     <GenerateDoc>true</GenerateDoc>
 
     <!-- Debug/Symbol properties -->

--- a/src/Destructurama.FSharp/Destructurama.FSharp.fsproj
+++ b/src/Destructurama.FSharp/Destructurama.FSharp.fsproj
@@ -37,11 +37,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <!--
-      We manually override the built-in version of FSharp.Core here so that the
-      version constraint range for package is better.
-    -->
-    <PackageReference Include="FSharp.Core" Version="[4.6.2, 4.7.0)" />
+    <PackageReference Include="FSharp.Core" Version="4.3.4" />
     <PackageReference Include="Serilog" Version="[2.8.0, 3.0.0)" />
 
     <!-- Build tools -->

--- a/src/Destructurama.FSharp/Destructurama.FSharp.fsproj
+++ b/src/Destructurama.FSharp/Destructurama.FSharp.fsproj
@@ -38,7 +38,7 @@
   
   <ItemGroup>
     <PackageReference Include="FSharp.Core" Version="4.3.4" />
-    <PackageReference Include="Serilog" Version="[2.8.0, 3.0.0)" />
+    <PackageReference Include="Serilog" Version="2.0.0" />
 
     <!-- Build tools -->
       <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19351-01" PrivateAssets="All"/>

--- a/test/Destructurama.FSharp.Test/Destructurama.FSharp.Test.fsproj
+++ b/test/Destructurama.FSharp.Test/Destructurama.FSharp.Test.fsproj
@@ -5,6 +5,7 @@
     <IsPackable>false</IsPackable>
     <GenerateProgramFile>false</GenerateProgramFile>
     <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
+    <DisableImplicitSystemValueTupleReference>true</DisableImplicitSystemValueTupleReference>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Destructurama.FSharp.Test/Destructurama.FSharp.Test.fsproj
+++ b/test/Destructurama.FSharp.Test/Destructurama.FSharp.Test.fsproj
@@ -13,8 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <!-- copied from the library project exactly, still not guaranteed to be the same, thanks Nuget. -->
-    <PackageReference Include="FSharp.Core" Version="[4.6.2, 4.7.0)" />
+    <PackageReference Include="FSharp.Core" Version="4.6.2" />
     <PackageReference Include="Serilog" Version="[2.8.0, 3.0.0)" />
 
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />


### PR DESCRIPTION
This applies a standard convention I've used with success across other projects (originally from Enrico and Dave in https://github.com/jet/falanx), whereby:

- the impl package depends on a packages only as new as strictly required
- test projects pull in newer versions as necessarily
- applications are then free to float Serilog and FSharp.Core as desired

This also includes some more debatable tidying stuff - please push back and I can remove them